### PR TITLE
Minor fixes to documentation and version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ _Home Assistant Integration to communicate with [sickgear][sickgear]._
 
 Platform | Description
 -- | --
-`binary_sensor` | Show something `True` or `False`.
+`switch` | Turn something `on` or `off`.
 `sensor` | Show info from blueprint API.
 
 ## Installation

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
     "name": "SickGear",
     "render_readme": true,
-    "homeassistant": ">=2023.3.0"
+    "homeassistant": "2023.3.0"
 }


### PR DESCRIPTION
- Fix the HA Version nomenclature
- Changed from "binary_sensor" to "switch" in documentation